### PR TITLE
⚽️ Add entities about team notice and team notice reply.

### DIFF
--- a/whistleon-back/src/main/java/io/hala/whistleon/domain/team/Team.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/domain/team/Team.java
@@ -2,6 +2,7 @@ package io.hala.whistleon.domain.team;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.springframework.lang.Nullable;
@@ -10,6 +11,7 @@ import javax.persistence.*;
 import java.time.LocalDate;
 
 @DynamicInsert
+@NoArgsConstructor
 @Getter
 @Entity(name = "team")
 public class Team {

--- a/whistleon-back/src/main/java/io/hala/whistleon/domain/team/TeamNotice.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/domain/team/TeamNotice.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -24,6 +26,9 @@ public class TeamNotice {
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "author")
     private User author;
+
+    @OneToMany(mappedBy = "teamNotice")
+    private List<TeamNoticeReply> teamNoticeReplies = new ArrayList<>();
 
     @Column(name = "title")
     private String title;

--- a/whistleon-back/src/main/java/io/hala/whistleon/domain/team/TeamNotice.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/domain/team/TeamNotice.java
@@ -1,0 +1,45 @@
+package io.hala.whistleon.domain.team;
+
+import io.hala.whistleon.domain.user.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@Entity(name = "team_notice")
+public class TeamNotice {
+    @Id
+    @GeneratedValue
+    @Column(name = "notice_id")
+    private Long noticeId;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "team_id")
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "author")
+    private User author;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "content")
+    private String content;
+
+    @Column(name = "date")
+    private LocalDate date;
+
+    @Builder
+    public TeamNotice(Team team, User author, String title, String content) {
+        this.team = team;
+        this.author = author;
+        this.title = title;
+        this.content = content;
+        this.date = LocalDate.now();
+    }
+}

--- a/whistleon-back/src/main/java/io/hala/whistleon/domain/team/TeamNoticeReply.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/domain/team/TeamNoticeReply.java
@@ -1,0 +1,41 @@
+package io.hala.whistleon.domain.team;
+
+import io.hala.whistleon.domain.user.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@Entity(name = "team_notice_reply")
+public class TeamNoticeReply {
+    @Id
+    @GeneratedValue
+    @Column(name = "reply_id")
+    private Long replyId;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "notice_id")
+    private TeamNotice teamNotice;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "author")
+    private User author;
+
+    @Column(name = "content")
+    private String content;
+
+    @Column(name = "date")
+    private LocalDate date;
+
+    @Builder
+    public TeamNoticeReply(TeamNotice teamNotice, User author, String content) {
+        this.teamNotice = teamNotice;
+        this.author = author;
+        this.content = content;
+        this.date = LocalDate.now();
+    }
+}

--- a/whistleon-back/src/main/java/io/hala/whistleon/domain/team/TeamNoticeReplyRepository.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/domain/team/TeamNoticeReplyRepository.java
@@ -1,0 +1,6 @@
+package io.hala.whistleon.domain.team;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamNoticeReplyRepository extends JpaRepository<TeamNoticeReply, Long> {
+}

--- a/whistleon-back/src/main/java/io/hala/whistleon/domain/team/TeamNoticeRepository.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/domain/team/TeamNoticeRepository.java
@@ -1,0 +1,6 @@
+package io.hala.whistleon.domain.team;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamNoticeRepository extends JpaRepository<TeamNotice, Long> {
+}

--- a/whistleon-back/src/test/java/io/hala/whistleon/domain/team/TeamNoticeTest.java
+++ b/whistleon-back/src/test/java/io/hala/whistleon/domain/team/TeamNoticeTest.java
@@ -1,0 +1,76 @@
+package io.hala.whistleon.domain.team;
+
+import io.hala.whistleon.domain.user.User;
+import io.hala.whistleon.domain.user.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest(properties = {"spring.config.location=classpath:application-dev.properties"})
+public class TeamNoticeTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private TeamNoticeRepository teamNoticeRepository;
+
+    @Autowired
+    private TeamNoticeReplyRepository teamNoticeReplyRepository;
+
+    @Test
+    @Transactional
+    void insertTest() throws Exception {
+        User user = userRepository.findById((long) 30).orElseThrow(() -> new Exception());
+        Team team = user.getTeam();
+
+        TeamNotice teamNotice = TeamNotice.builder()
+                .team(team)
+                .author(user)
+                .title("아슬란 첫경기 관련 공지사항입니다.")
+                .content("30분전에 도착해주세요 유니폼 지급합니다.")
+                .build();
+        //When
+        Long teamNoticeId = teamNoticeRepository.save(teamNotice).getNoticeId();
+        TeamNotice findTeamNotice = teamNoticeRepository.findById(teamNoticeId).orElseThrow(() -> new Exception());
+
+        //Then
+        assertThat(findTeamNotice).isEqualTo(teamNotice);
+    }
+
+    @Test
+    @Transactional
+    void insertReplyTest() throws Exception {
+        //mock data
+        TeamNotice teamNotice = teamNoticeRepository.findById((long) 44).orElseThrow(() -> new Exception());
+        User author = userRepository.findById((long) 30).orElseThrow(() -> new Exception());
+        TeamNoticeReply teamNoticeReply = TeamNoticeReply.builder()
+                .teamNotice(teamNotice)
+                .author(author)
+                .content("네 알겠습니다!!")
+                .build();
+
+        teamNoticeReplyRepository.save(teamNoticeReply);
+    }
+
+    @Test
+    @Transactional
+    void findReplyTest() throws Exception {
+        //mock data
+        TeamNotice teamNotice = teamNoticeRepository.findById((long) 44).orElseThrow(() -> new Exception());
+        List<TeamNoticeReply> teamNoticeReplies = teamNotice.getTeamNoticeReplies();
+        for (TeamNoticeReply teamNoticeReply : teamNoticeReplies) {
+            assertThat(teamNoticeReply.getContent()).isEqualTo("네 알겠습니다!!");
+        }
+    }
+}

--- a/whistleon-back/src/test/java/io/hala/whistleon/domain/team/TeamTest.java
+++ b/whistleon-back/src/test/java/io/hala/whistleon/domain/team/TeamTest.java
@@ -1,6 +1,9 @@
 package io.hala.whistleon.domain.team;
 
 
+import io.hala.whistleon.domain.user.User;
+import io.hala.whistleon.domain.user.UserRepository;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,6 +21,8 @@ public class TeamTest {
     @Autowired
     private TeamRepository teamRepository;
 
+    @Autowired
+    private UserRepository userRepository;
 
     @Transactional
     @Test
@@ -43,5 +48,18 @@ public class TeamTest {
 
         assertThat(findTeam.isPresent()).isEqualTo(true);
         assertThat(findTeam.get()).isEqualTo(team);
+    }
+
+    /**
+     * mock data test
+     */
+    @Transactional
+    @Test
+    void userTeamTest() throws Exception {
+        User user = userRepository.findById((long) 30).orElseThrow(() -> new Exception());
+        Team team = teamRepository.findById((long) 41).orElseThrow(() -> new Exception());
+
+        assertThat(user.getTeam()).isEqualTo(team);
+
     }
 }


### PR DESCRIPTION
I have been currently designing Entity Class from DB tables.
This pr is related to Team Domain which contains 'TeamNotice' and 'TeamNoticeReply'.

* create team notice and team notice reply entities.
* update team and team notice entities. 
    * add `@NoArgsConstructor`, for the same reason https://github.com/mostoriginaldudes/WhistleOn/pull/11.
    * add `@OneToMany` column on TeamNotice. By adding this annotation, TeamNotice and TeamNoticeReply have a two-way association.
* test code