### PR TITLE
⚽️ Add entities about match

### DIFF
--- a/whistleon-back/src/main/java/io/hala/whistleon/domain/match/Match.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/domain/match/Match.java
@@ -1,0 +1,93 @@
+package io.hala.whistleon.domain.match;
+
+import io.hala.whistleon.domain.user.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+import org.springframework.lang.Nullable;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@DynamicInsert
+@Getter
+@NoArgsConstructor
+@Entity(name = "match")
+public class Match {
+    @Id
+    @GeneratedValue
+    @Column(name = "match_id")
+    private Long matchId;
+
+    @Nullable
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "mom_user")
+    private User momUser;
+
+    @Column(name = "kickoff_time")
+    private LocalDate kickoffTime;
+
+    @Column(name = "status")
+    @ColumnDefault("BEFORE")
+    private MatchStatus status;
+
+    @Column(name = "location")
+    private String location;
+
+    @Column(name = "stadium")
+    private String stadium;
+
+    @Column(name = "home_score")
+    @ColumnDefault("0")
+    private Integer homeScore;
+
+    @Column(name = "away_score")
+    @ColumnDefault("0")
+    private Integer awayScore;
+
+    @Builder
+    public Match(LocalDate kickoffTime, String location, String stadium) {
+        this.kickoffTime = kickoffTime;
+        this.location = location;
+        this.stadium = stadium;
+    }
+
+    /**
+     * After match finished, Leader can update homeScore and awayScore.
+     * We will give points to team, if they update score.
+     * @param homeScore
+     * @param awayScore
+     * @return random points(1~100)
+     * @throws Exception
+     */
+    public int updateScore(int homeScore, int awayScore) throws Exception {
+        if (homeScore >= 0) {
+            this.homeScore = homeScore;
+        } else {
+            // I will update Exception about score.
+            throw new Exception();
+        }
+
+        if (awayScore >= 0) {
+            this.awayScore = awayScore;
+        } else {
+            // I will update Exception about score.
+            throw new Exception();
+        }
+
+        return 1;
+    }
+
+    /**
+     * Leader can give mom title to some user using this method.
+     * We will also give some points if they update momPlayer.
+     * @param user
+     * @return points(1~100)
+     */
+    public int updateMomPlayer(User user) {
+        this.momUser = user;
+        return 1;
+    }
+}

--- a/whistleon-back/src/main/java/io/hala/whistleon/domain/match/Match.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/domain/match/Match.java
@@ -10,6 +10,7 @@ import org.springframework.lang.Nullable;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @DynamicInsert
 @Getter
@@ -27,8 +28,9 @@ public class Match {
     private User momUser;
 
     @Column(name = "kickoff_time")
-    private LocalDate kickoffTime;
+    private LocalDateTime kickoffTime;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "status")
     @ColumnDefault("BEFORE")
     private MatchStatus status;
@@ -48,7 +50,7 @@ public class Match {
     private Integer awayScore;
 
     @Builder
-    public Match(LocalDate kickoffTime, String location, String stadium) {
+    public Match(LocalDateTime kickoffTime, String location, String stadium) {
         this.kickoffTime = kickoffTime;
         this.location = location;
         this.stadium = stadium;

--- a/whistleon-back/src/main/java/io/hala/whistleon/domain/match/MatchRepository.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/domain/match/MatchRepository.java
@@ -1,0 +1,6 @@
+package io.hala.whistleon.domain.match;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchRepository extends JpaRepository<Match, Long> {
+}

--- a/whistleon-back/src/main/java/io/hala/whistleon/domain/match/MatchStatus.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/domain/match/MatchStatus.java
@@ -1,0 +1,5 @@
+package io.hala.whistleon.domain.match;
+
+public enum MatchStatus {
+    BEFORE, ING, DONE
+}

--- a/whistleon-back/src/main/java/io/hala/whistleon/domain/match/TeamMatch.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/domain/match/TeamMatch.java
@@ -1,0 +1,38 @@
+package io.hala.whistleon.domain.match;
+
+import io.hala.whistleon.domain.team.Team;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity(name = "team_match")
+public class TeamMatch {
+    @Id
+    @GeneratedValue
+    @Column(name = "team_match_id")
+    private Long teamMatchId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "match_id")
+    private Match match;
+
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "team_status")
+    private TeamStatus teamStatus; // [HOME, AWAY]
+
+    @Builder
+    public TeamMatch(Team team, Match match, TeamStatus teamStatus) {
+        this.team = team;
+        this.match = match;
+        this.teamStatus = teamStatus;
+    }
+}

--- a/whistleon-back/src/main/java/io/hala/whistleon/domain/match/TeamMatchRepository.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/domain/match/TeamMatchRepository.java
@@ -1,0 +1,6 @@
+package io.hala.whistleon.domain.match;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamMatchRepository extends JpaRepository<TeamMatch, Long> {
+}

--- a/whistleon-back/src/main/java/io/hala/whistleon/domain/match/TeamStatus.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/domain/match/TeamStatus.java
@@ -1,0 +1,5 @@
+package io.hala.whistleon.domain.match;
+
+public enum TeamStatus {
+    HOME, AWAY
+}

--- a/whistleon-back/src/test/java/io/hala/whistleon/domain/match/MatchTest.java
+++ b/whistleon-back/src/test/java/io/hala/whistleon/domain/match/MatchTest.java
@@ -1,0 +1,52 @@
+package io.hala.whistleon.domain.match;
+
+import io.hala.whistleon.domain.team.Team;
+import io.hala.whistleon.domain.team.TeamRepository;
+import io.hala.whistleon.domain.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest(properties = {"spring.config.location=classpath:application-dev.properties"})
+public class MatchTest {
+    @Autowired
+    private MatchRepository matchRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private TeamMatchRepository teamMatchRepository;
+
+    @Test
+    @Transactional
+    void insertTest() throws Exception {
+        Match match = Match.builder()
+                .kickoffTime(LocalDateTime.now())
+                .location("인천광역시 연수구 청학동")
+                .stadium("용담근린공원")
+                .build();
+
+        matchRepository.save(match);
+
+        Team homeTeam = teamRepository.findById((long) 41).orElseThrow(() -> new Exception());
+        TeamMatch teamMatch = TeamMatch.builder()
+                .match(match)
+                .team(homeTeam)
+                .teamStatus(TeamStatus.HOME)
+                .build();
+
+        Match findMatch = teamMatchRepository.save(teamMatch).getMatch();
+        assertThat(findMatch).isEqualTo(match);
+    }
+}


### PR DESCRIPTION
I have been currently designing Entity Class from DB tables.
This pr is related to Match Domain which contains 'Match' and 'TeamMatch'.

* create Match and TeamMatch entities.
* update kickoffTime field in Match.
* Add MatchStatus and TeamStatus Enum class.
* test code
* I add `spring.jpa.properties.hibernate.globally_quoted_identifiers=true` in `application.properties`, because `match` is keyword in MariaDB. By adding this setting, hibernate add quote in query.
