### PR TITLE
🚥 Update one-to-many field in team entity

### DIFF
--- a/whistleon-back/src/main/java/io/hala/whistleon/domain/team/Team.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/domain/team/Team.java
@@ -1,5 +1,6 @@
 package io.hala.whistleon.domain.team;
 
+import io.hala.whistleon.domain.user.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,8 @@ import org.springframework.lang.Nullable;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @DynamicInsert
 @NoArgsConstructor
@@ -43,6 +46,9 @@ public class Team {
 
     @Column(name = "found_date")
     private LocalDate foundDate;
+
+    @OneToMany(mappedBy = "team")
+    private List<User> users = new ArrayList<>();
 
     @Builder
     public Team(String name, String location, String email, String description, LocalDate foundDate) {


### PR DESCRIPTION
I add one-to-many field in team entity, so I can access team users using `List<User> users = team.getUsers()`.

Actually, I didn't want to use 2-way mappings unless I really needed it, but it is useful in creating vote.