### PR TITLE
User 인증 관련 구현 완료

### DIFF
--- a/whistleon-back/src/main/java/io/hala/whistleon/common/interceptor/JwtInterceptor.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/common/interceptor/JwtInterceptor.java
@@ -36,7 +36,6 @@ public class JwtInterceptor implements HandlerInterceptor{
      */
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
-        System.out.println(HEADER_AUTH);
         final String token = request.getHeader(HEADER_AUTH);
         if (token != null && jwtService.isUsableToken(token)) {
             return true;
@@ -45,15 +44,5 @@ public class JwtInterceptor implements HandlerInterceptor{
             response.sendRedirect("/");
             return false;
         }
-    }
-
-    @Override
-    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
-
-    }
-
-    @Override
-    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
-
     }
 }

--- a/whistleon-back/src/main/java/io/hala/whistleon/controller/AuthController.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/controller/AuthController.java
@@ -1,11 +1,15 @@
 package io.hala.whistleon.controller;
 
+import io.hala.whistleon.controller.dto.LoginResponseDto;
+import io.hala.whistleon.controller.dto.SigninRequestDto;
 import io.hala.whistleon.service.user.AuthService;
 import io.hala.whistleon.service.user.UserService;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.constraints.Email;
 
 @RequiredArgsConstructor
@@ -27,5 +31,13 @@ public class AuthController {
     public ResponseEntity<?> authCode(@PathVariable @Email String email, @PathVariable String code) {
         authService.authCode(email, code);
         return ResponseEntity.ok(null);
+    }
+
+    @ApiOperation("로그인")
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponseDto> signin(@RequestBody SigninRequestDto signinRequestDto, HttpServletResponse response) {
+        String token = authService.signin(signinRequestDto);
+        response.setHeader("Authorization", token);
+        return ResponseEntity.ok(userService.getLoginUserInfo(signinRequestDto));
     }
 }

--- a/whistleon-back/src/main/java/io/hala/whistleon/controller/UserController.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/controller/UserController.java
@@ -6,10 +6,7 @@ import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -25,5 +22,12 @@ public class UserController {
     public ResponseEntity<?> registUser(@RequestBody @Valid SignupRequestDto signupRequestDto) {
         userService.signup(signupRequestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(null);
+    }
+
+    @ApiOperation("닉네임 중복 여부 확인")
+    @GetMapping("/nickname/{nickname}")
+    public ResponseEntity<?> checkNickname(@PathVariable String nickname) {
+        userService.checkExistNickname(nickname);
+        return ResponseEntity.ok(null);
     }
 }

--- a/whistleon-back/src/main/java/io/hala/whistleon/controller/dto/LoginResponseDto.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/controller/dto/LoginResponseDto.java
@@ -1,0 +1,11 @@
+package io.hala.whistleon.controller.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class LoginResponseDto {
+    private Long userId;
+    private String nickname;
+}

--- a/whistleon-back/src/main/java/io/hala/whistleon/controller/dto/SigninRequestDto.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/controller/dto/SigninRequestDto.java
@@ -1,0 +1,16 @@
+package io.hala.whistleon.controller.dto;
+
+
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SigninRequestDto {
+    @NotNull
+    private String email;
+    @NotNull
+    private String password;
+}

--- a/whistleon-back/src/main/java/io/hala/whistleon/controller/dto/SignupRequestDto.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/controller/dto/SignupRequestDto.java
@@ -10,8 +10,7 @@ import java.time.LocalDate;
 
 @Getter
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class SignupRequestDto {
     @NotNull
     @Email

--- a/whistleon-back/src/main/java/io/hala/whistleon/domain/user/UserRepository.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/domain/user/UserRepository.java
@@ -6,4 +6,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    Optional<User> findUsersByNickname(String nickname);
 }

--- a/whistleon-back/src/main/java/io/hala/whistleon/domain/user/UserRepository.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/domain/user/UserRepository.java
@@ -8,4 +8,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     Optional<User> findUsersByNickname(String nickname);
+
+    Optional<User> findUserByEmailAndPassword(String email, String password);
 }

--- a/whistleon-back/src/main/java/io/hala/whistleon/service/login/JwtService.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/service/login/JwtService.java
@@ -1,7 +1,9 @@
 package io.hala.whistleon.service.login;
 
+import io.hala.whistleon.domain.user.User;
+
 public interface JwtService {
-    String createToken(String user);
-    boolean isUsableToken(String jwt) throws UnauthorizedException;
+    String createToken(User user);
+    boolean isUsableToken(String jwt);
     Object getToken(String key) throws Exception;
 }

--- a/whistleon-back/src/main/java/io/hala/whistleon/service/login/JwtServiceImpl.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/service/login/JwtServiceImpl.java
@@ -1,12 +1,18 @@
 package io.hala.whistleon.service.login;
 
+import io.hala.whistleon.common.exception.CustomException;
+import io.hala.whistleon.common.exception.ExceptionCode;
+import io.hala.whistleon.domain.user.User;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+
+import java.util.Date;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -14,48 +20,41 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 @Service
 public class JwtServiceImpl implements JwtService {
 
-    @Value("${jwt.header.auth}")
-    private String HEADER_AUTH;
-
     @Value("${jwt.salt.value}")
     private String SALT;
 
     /**
-     *
      * @param user
      * @return jwt token
      */
     @Override
-    public String createToken(String user) {
-//        String jwt = Jwts.builder()
-//                .setHeaderParam("typ", "JWT")
-//                .setHeaderParam("regDate", System.currentTimeMillis())
-//                .setSubject(user.getEmail())
-//                .claim("userId", user.getUserId())
-//                .claim("email", user.getEmail())
-//                .claim("userName", user.getName())
-//                .setExpiration(new Date(System.currentTimeMillis() + (1000 * 60 * 60)))
-//                .signWith(SignatureAlgorithm.HS256, this.generateKey())
-//                .compact();
-//        return jwt;
-        return null;
+    public String createToken(User user) {
+        String jwt = Jwts.builder()
+                .setHeaderParam("typ", "JWT")
+                .setHeaderParam("regDate", System.currentTimeMillis())
+                .setSubject(user.getEmail())
+                .claim("userId", user.getUserId())
+                .claim("email", user.getEmail())
+                .claim("userName", user.getName())
+                .setExpiration(new Date(System.currentTimeMillis() + (1000 * 60 * 60)))
+                .signWith(SignatureAlgorithm.HS256, this.generateKey())
+                .compact();
+        return jwt;
     }
 
     /**
-     *
      * @param jwt
      * @return checking token, then returns true or false.
-     * @throws UnauthorizedException
      */
     @Override
-    public boolean isUsableToken(String jwt) throws UnauthorizedException {
+    public boolean isUsableToken(String jwt) {
         try {
             Jws<Claims> claims = Jwts.parser()
                     .setSigningKey(this.generateKey())
                     .parseClaimsJws(jwt);
             return true;
         } catch (Exception e) {
-            throw new UnauthorizedException();
+            throw new CustomException(ExceptionCode.UNAUTHORIZED_MEMBER);
         }
     }
 

--- a/whistleon-back/src/main/java/io/hala/whistleon/service/user/AuthService.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/service/user/AuthService.java
@@ -1,5 +1,7 @@
 package io.hala.whistleon.service.user;
 
+import io.hala.whistleon.controller.dto.SigninRequestDto;
+
 public interface AuthService {
     void authEmail(String to);
 
@@ -9,4 +11,5 @@ public interface AuthService {
 
     void deleteCode(long id);
 
+    String signin(SigninRequestDto signinRequestDto);
 }

--- a/whistleon-back/src/main/java/io/hala/whistleon/service/user/AuthServiceImpl.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/service/user/AuthServiceImpl.java
@@ -3,19 +3,26 @@ package io.hala.whistleon.service.user;
 import io.hala.whistleon.common.exception.CustomException;
 import io.hala.whistleon.common.exception.ExceptionCode;
 import io.hala.whistleon.common.util.MailSendHelper;
+import io.hala.whistleon.controller.dto.SigninRequestDto;
 import io.hala.whistleon.domain.user.AuthCode;
 import io.hala.whistleon.domain.user.AuthRepository;
+import io.hala.whistleon.domain.user.User;
+import io.hala.whistleon.domain.user.UserRepository;
+import io.hala.whistleon.service.login.JwtService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
 public class AuthServiceImpl implements AuthService {
 
     private final MailSendHelper mailSendHelper;
+    private final JwtService jwtService;
     private final AuthRepository authRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     @Override
@@ -59,5 +66,12 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public void deleteCode(long id) {
         authRepository.deleteById(id);
+    }
+
+    @Override
+    public String signin(SigninRequestDto signinRequestDto) {
+        User user = userRepository.findUserByEmailAndPassword(signinRequestDto.getEmail(), signinRequestDto.getPassword())
+                .orElseThrow(() -> new CustomException(ExceptionCode.UNAUTHORIZED_MEMBER));
+        return jwtService.createToken(user);
     }
 }

--- a/whistleon-back/src/main/java/io/hala/whistleon/service/user/UserService.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/service/user/UserService.java
@@ -6,4 +6,6 @@ public interface UserService {
     void signup(SignupRequestDto signupRequestDto);
 
     boolean checkEmail(String email);
+
+    void checkExistNickname(String nickname);
 }

--- a/whistleon-back/src/main/java/io/hala/whistleon/service/user/UserService.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/service/user/UserService.java
@@ -1,5 +1,7 @@
 package io.hala.whistleon.service.user;
 
+import io.hala.whistleon.controller.dto.LoginResponseDto;
+import io.hala.whistleon.controller.dto.SigninRequestDto;
 import io.hala.whistleon.controller.dto.SignupRequestDto;
 
 public interface UserService {
@@ -8,4 +10,6 @@ public interface UserService {
     boolean checkEmail(String email);
 
     void checkExistNickname(String nickname);
+
+    LoginResponseDto getLoginUserInfo(SigninRequestDto signinRequestDto);
 }

--- a/whistleon-back/src/main/java/io/hala/whistleon/service/user/UserServiceImpl.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/service/user/UserServiceImpl.java
@@ -36,4 +36,12 @@ public class UserServiceImpl implements UserService{
         }
         return true;
     }
+
+    @Override
+    public void checkExistNickname(String nickname) {
+        Optional<User> findUser = userRepository.findUsersByNickname(nickname);
+        if (findUser.isPresent()) {
+            throw new CustomException(ExceptionCode.DUPLICATE_DATA);
+        }
+    }
 }

--- a/whistleon-back/src/main/java/io/hala/whistleon/service/user/UserServiceImpl.java
+++ b/whistleon-back/src/main/java/io/hala/whistleon/service/user/UserServiceImpl.java
@@ -2,6 +2,8 @@ package io.hala.whistleon.service.user;
 
 import io.hala.whistleon.common.exception.CustomException;
 import io.hala.whistleon.common.exception.ExceptionCode;
+import io.hala.whistleon.controller.dto.LoginResponseDto;
+import io.hala.whistleon.controller.dto.SigninRequestDto;
 import io.hala.whistleon.controller.dto.SignupRequestDto;
 import io.hala.whistleon.domain.user.User;
 import io.hala.whistleon.domain.user.UserRepository;
@@ -43,5 +45,15 @@ public class UserServiceImpl implements UserService{
         if (findUser.isPresent()) {
             throw new CustomException(ExceptionCode.DUPLICATE_DATA);
         }
+    }
+
+    @Override
+    public LoginResponseDto getLoginUserInfo(SigninRequestDto signinRequestDto) {
+        User user = userRepository.findUserByEmailAndPassword(signinRequestDto.getEmail(), signinRequestDto.getPassword())
+                .orElseThrow(() -> new CustomException(ExceptionCode.UNAUTHORIZED_MEMBER));
+        return LoginResponseDto.builder()
+                .userId(user.getUserId())
+                .nickname(user.getNickname())
+                .build();
     }
 }

--- a/whistleon-back/src/test/java/io/hala/whistleon/domain/user/UserTest.java
+++ b/whistleon-back/src/test/java/io/hala/whistleon/domain/user/UserTest.java
@@ -1,8 +1,8 @@
 package io.hala.whistleon.domain.user;
 
-import io.hala.whistleon.controller.UserController;
+import io.hala.whistleon.common.exception.CustomException;
 import io.hala.whistleon.service.user.UserService;
-import io.hala.whistleon.service.user.UserServiceImpl;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -15,7 +15,8 @@ import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest(properties = {"spring.config.location=classpath:application-dev.properties"})
 public class UserTest {
-
+    @Autowired
+    private UserService userService;
     @Autowired
     private UserRepository userRepository;
 
@@ -55,5 +56,16 @@ public class UserTest {
 
         assertThat(findUser.isPresent()).isEqualTo(true);
         assertThat(findUser.get()).isEqualTo(user);
+    }
+
+    @Test
+    void checkNicknameTest() {
+        String existNickname = "강상우";
+        assertThatThrownBy(() -> userService.checkDuplicateNickname(existNickname))
+                .isInstanceOf(CustomException.class);
+
+        String noneExistNickname = "neverEverUseThisNickname";
+        assertThatCode(() -> userService.checkDuplicateNickname(noneExistNickname))
+                .doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
### 닉네임 중복확인 api 구현 완료
* GET /users/nickname/{nickname}
* 성공할 경우 200, 이미 닉네임 존재할 경우 409로 응답합니다.
* 테스트 코드

### 로그인 기능 기본적인 구현 완료
* jwt를 사용한 로그인 api를 구현하였습니다.
* 다만, 아직 형식적인 수준일 뿐이라서 스프링 시큐리티 및 jwt에 대한 공부를 진행하며 이 부분은 개선해나갈 예정입니다
* POST /auth/login (request body에 이메일과 패스워드)
* 응답 헤더에 토큰정보를 넣어서 반환해줍니다.
* jwt 인터셉터 구현완료하였습니다.

### 추가 세팅
* lombok 라이브러리 관련하여 빌더패턴이 유의미하도록 변경하였습니다.