### PR TITLE
SCSS import문 중복되는 문제 해결

### DIFF
--- a/whistleon-front/src/components/EventButton/event-button.scoped.scss
+++ b/whistleon-front/src/components/EventButton/event-button.scoped.scss
@@ -1,5 +1,3 @@
-@import '../../style/main';
-
 .event_button {
   @include size(190px, 50px);
   border-radius: 5px;

--- a/whistleon-front/src/components/Home/home.scoped.scss
+++ b/whistleon-front/src/components/Home/home.scoped.scss
@@ -1,5 +1,3 @@
-@import '../../style/main';
-
 .home {
   &__container {
     @include flex(row);

--- a/whistleon-front/src/components/InputUnderline/input-underline.scoped.scss
+++ b/whistleon-front/src/components/InputUnderline/input-underline.scoped.scss
@@ -1,5 +1,3 @@
-@import '../../style/main';
-
 $gap: 10px;
 
 @mixin input-transition() {

--- a/whistleon-front/src/components/LinkButton/link-button.scoped.scss
+++ b/whistleon-front/src/components/LinkButton/link-button.scoped.scss
@@ -1,5 +1,3 @@
-@import '../../style/main';
-
 .common {
   &__btn {
     @include flex(row, center, center);

--- a/whistleon-front/src/components/Login/login.scoped.scss
+++ b/whistleon-front/src/components/Login/login.scoped.scss
@@ -1,5 +1,3 @@
-@import '../../style/main';
-
 .login {
   &__wrapper {
     @include card($w: 480px, $margin: auto);

--- a/whistleon-front/src/components/PostCode/post-code.scoped.scss
+++ b/whistleon-front/src/components/PostCode/post-code.scoped.scss
@@ -1,5 +1,3 @@
-@import '../../style/main';
-
 $address-popup-width: 500px;
 $address-popup-height: 650px;
 

--- a/whistleon-front/src/components/Signup/signup.scoped.scss
+++ b/whistleon-front/src/components/Signup/signup.scoped.scss
@@ -1,5 +1,3 @@
-@import '../../style/main';
-
 .signup {
   &__wrapper {
     @include card($h: null, $margin: null);

--- a/whistleon-front/src/style/main.scss
+++ b/whistleon-front/src/style/main.scss
@@ -1,3 +1,2 @@
-@import 'root';
-@import 'color';
-@import 'mixin';
+@import 'root', 'color';
+

--- a/whistleon-front/webpack.config.js
+++ b/whistleon-front/webpack.config.js
@@ -40,14 +40,15 @@ module.exports = {
         }
       },
       {
-        test: /\.s?css$/,
+        test: /\.scoped\.s?css$/,
         use: [
           MiniCssExtractPlugin.loader,
           'css-loader',
           {
             loader: 'sass-loader',
             options: {
-              implementation: require('sass')
+              implementation: require('sass'),
+              additionalData:  `@import '../../style/main';`
             }
           }
         ]


### PR DESCRIPTION
* [x] `webpack.config.js` SCSS rules에서 `additionalData` 속성을 정의하여 import문 자동으로 prepend되도록 설정
* [x]  `*.scoped.scss` 파일에서 `@import`문 제거
* [x] `main.scss` 내부의 import문 간단하게 만들기